### PR TITLE
Google mobility data

### DIFF
--- a/data/county_level/processed/google_mobility/clean.py
+++ b/data/county_level/processed/google_mobility/clean.py
@@ -8,17 +8,17 @@ def clean(data_path='../../raw/google_mobility/google.csv',
 
     Output will have columns:
     - Country
-    - State/Province
+    - State (also province, or any region bigger than county)
     - County
     - Date (YYYY-MM-DD)
-    - Region Type (one of {County, State/Province, Country}, level of granularity)
+    - Region Type (one of {County, State, Country}, level of granularity)
     - Sector (one of {parks, retail_and_recreation, transit, workplaces,
         residential, grocery_and_pharmacy})
     """
     # Naming of region granularities
     rename_dict = {
         'sub_region_2': 'County',
-        'sub_region_1': 'Region',
+        'sub_region_1': 'State',
         'country_region': 'Country',
         'date': 'Date',
     }
@@ -39,7 +39,7 @@ def clean(data_path='../../raw/google_mobility/google.csv',
     goog_df = goog_df.rename(columns=rename_dict)
     goog_df['Sector'] = goog_df['Sector'].apply(lambda x: sector_dict[x])
 
-    for region_type in ['Country', 'Region', 'County']:
+    for region_type in ['Country', 'State', 'County']:
         this_granularity = goog_df[~goog_df[region_type].isna()].index
         goog_df.loc[this_granularity, 'Region Type'] = region_type
     goog_df.to_csv('google.csv', index=False)

--- a/data/county_level/processed/google_mobility/clean.py
+++ b/data/county_level/processed/google_mobility/clean.py
@@ -1,0 +1,48 @@
+import pandas as pd
+from pathlib import Path
+
+def clean(data_path='../../raw/google_mobility/google.csv',
+            convenience_cols=True):
+    """
+    Clean google mobility data
+
+    Output will have columns:
+    - Country
+    - State/Province
+    - County
+    - Date (YYYY-MM-DD)
+    - Region Type (one of {County, State/Province, Country}, level of granularity)
+    - Sector (one of {parks, retail_and_recreation, transit, workplaces,
+        residential, grocery_and_pharmacy})
+    """
+    # Naming of region granularities
+    rename_dict = {
+        'sub_region_2': 'County',
+        'sub_region_1': 'Region',
+        'country_region': 'Country',
+        'date': 'Date',
+    }
+    sector_dict = {
+        'retail_and_recreation': 'Retail-Recreation',
+        'grocery_and_pharmacy': 'Grocery-Pharmacy',
+        'parks': 'Parks',
+        'transit_stations': 'Transit',
+        'workplaces': 'Workplace',
+        'residential': 'Residential'
+    }
+    sector_dict = {k + '_percent_change_from_baseline': sector_dict[k] for k in sector_dict}
+    
+    # Load raw data
+    goog_df = pd.read_csv(Path(__file__).parent.absolute() / data_path)
+    goog_df = pd.melt(goog_df, id_vars=rename_dict.keys(), value_vars=sector_dict.keys(), 
+                                var_name='Sector', value_name='Percent Change')
+    goog_df = goog_df.rename(columns=rename_dict)
+    goog_df['Sector'] = goog_df['Sector'].apply(lambda x: sector_dict[x])
+
+    for region_type in ['Country', 'Region', 'County']:
+        this_granularity = goog_df[~goog_df[region_type].isna()].index
+        goog_df.loc[this_granularity, 'Region Type'] = region_type
+    goog_df.to_csv('google.csv', index=False)
+
+if __name__ == '__main__':
+    clean()

--- a/data/county_level/raw/google_mobility/download.py
+++ b/data/county_level/raw/google_mobility/download.py
@@ -1,0 +1,2 @@
+import os
+os.system("wget https://www.gstatic.com/covid19/mobility/Global_Mobility_Report.csv -O google.csv")


### PR DESCRIPTION
Added simple scripts for pulling and lightly cleaning data from Google Community Mobility reports.

One thing I removed (since it seemed easy for people to just do themselves) but that I am happy to add back is a column with integer granularity (0,1,2) in addition to Region Type, e.g. 
```python
granularity_df = {'County': 2, 'State': 1, 'Country': 0}
goog_df['Granularity'] = goog_df['Region Type'].apply(lambda x: granularity_df[x])
```